### PR TITLE
Updated manual.tex

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -1,4 +1,3 @@
-
 % This is LLNCS.DEM the demonstration file of
 % the LaTeX macro package from Springer-Verlag
 % for Lecture Notes in Computer Science,
@@ -641,16 +640,16 @@ n: 10
 
 
 
-\subsubsection{Unegistering Handlers}
+\subsubsection{Unregistering Handlers}
 
 Handlers can be unregistered from events with the \code{-=}
-operator. When a handler is unregistered, is not executed when the
+operator. When a handler is unregistered, it is not executed when the
 event is fired.
 
 \begin{codenv}
 val e = new ImperativeEvent[Int]()
-val handler1 = { x: Int => println(x) 
-val handler2 = { x: Int => println(f"n: $x") } (*@\label{$}@*)
+val handler1 = { x: Int => println(x) }
+val handler2 = { x: Int => println(s"n: $x") } (*@\label{$}@*)
 
 e += handler1
 e += handler2


### PR DESCRIPTION
- fixed two tiny typos
- fixed example code
- example code: replaced the `f` string interpolator with the `s` string interpolator (features of `f` string interpolator are not used here)
