### PR TITLE
Updated manual.tex

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -1,4 +1,3 @@
-
 % This is LLNCS.DEM the demonstration file of
 % the LaTeX macro package from Springer-Verlag
 % for Lecture Notes in Computer Science,
@@ -749,7 +748,7 @@ value of the resulting event.
 \begin{codenv}
 val e = new ImperativeEvent[Int]()
 val e_MAP: Event[String] = e map ((x: Int) => x.toString) 
-e_MAP += ((x: String) => println("Here: $x")) (*@\label{$}@*)
+e_MAP += ((x: String) => println(s"Here: $x")) (*@\label{$}@*)
 e(5)
 e(15)
 -- output ----


### PR DESCRIPTION
- fixed "Map Events" example (added string interpolator `s`)
