### PR TITLE
Dependencies Stored Multiple Times

### DIFF
--- a/REScala/src/react/Deprecated.scala
+++ b/REScala/src/react/Deprecated.scala
@@ -72,7 +72,7 @@ class StaticSignal[+T](reactivesDependsOn: List[DepHolder])(expr: => T)
     if (r.level >= level) level = r.level + 1 // For glitch freedom  
     r.addDependent(this) // To be notified in the future
   }) // check
-  dependOn ++= reactivesDependsOn
+  addAllDependOn(reactivesDependsOn)
 
   def triggerReevaluation() = reEvaluate
 

--- a/REScala/src/react/DynamicDepReactives.scala
+++ b/REScala/src/react/DynamicDepReactives.scala
@@ -93,7 +93,7 @@ class SignalSynt[+T](reactivesDependsOnUpperBound: List[DepHolder])(expr: Signal
     ReactiveEngine.log.nodeEvaluationEnded(this)
     //val hashAfter = tmp.hashCode
 
-    dependOn ++= reactivesDependsOnCurrent
+    addAllDependOn(reactivesDependsOnCurrent)
     reactivesDependsOnCurrent.map(_.addDependent(this))
 
     /* Notify dependents only of the value changed */

--- a/REScala/src/react/IFunctions.scala
+++ b/REScala/src/react/IFunctions.scala
@@ -160,7 +160,7 @@ class FoldedSignal[+T, +E](e: Event[E], init: T, f: (T, E) => T)
   }
 
   // The only dependant is e
-  dependOn += e
+  addDependOn(e)
   e.addDependent(this)
   this.level = e.level + 1
 
@@ -226,18 +226,18 @@ class SwitchedSignal[+T, +E](e: Event[E], init: Signal[T], factory: IFunctions.F
   }
 
   private def removeInner(s: Signal[_]) {
-    dependOn -= s
+    removeDependOn(s)
     s.removeDependent(this)
   }
 
   private def addInner(s: Signal[_]) {
-    dependOn += s
+    addDependOn(s)
     s.addDependent(this)
     this.level = math.max(e.level, s.level) + 1
   }
 
   // Switched signal depends on event and the current signal
-  dependOn += e
+  addDependOn(e)
   e.addDependent(this)
   addInner(currentSignal)
 

--- a/REScala/src/react/Reactives.scala
+++ b/REScala/src/react/Reactives.scala
@@ -27,8 +27,15 @@ object Reactive {
 trait DepHolder extends Reactive {
   val dependents = new ListBuffer[Dependent]
   def addDependent(dep: Dependent) = {
-    dependents += dep
-    ReactiveEngine.log.nodeAttached(dep, this)
+    if (!dependents.contains(dep)) {
+      dependents += dep
+      ReactiveEngine.log.nodeAttached(dep, this)
+    }
+  }
+  def addAllDependent(deps: TraversableOnce[Dependent]) = {
+    for (dep <- deps) {
+      addDependent(dep)
+    }
   }
   def removeDependent(dep: Dependent) = dependents -= dep
   def notifyDependents(change: Any): Unit = {
@@ -42,8 +49,15 @@ trait Dependent extends Reactive {
   val dependOn = new ListBuffer[DepHolder]
   // TODO: add level checking to have glitch freedom ?
   def addDependOn(dep: DepHolder) = {
-    dependOn += dep
-    ReactiveEngine.log.nodeAttached(this, dep)
+    if (!dependOn.contains(dep)) {
+      dependOn += dep
+      ReactiveEngine.log.nodeAttached(this, dep)
+    }
+  }
+  def addAllDependOn(deps: TraversableOnce[DepHolder]) = {
+    for (dep <- deps) {
+      addDependOn(dep)
+    }
   }
   def removeDependOn(dep: DepHolder) = dependOn -= dep
 

--- a/REScala/src/react/events/Events.scala
+++ b/REScala/src/react/events/Events.scala
@@ -156,7 +156,7 @@ class ChangedEventNode[T](d: DepHolder) extends EventNode[T] with Dependent {
 
   level = d.level + 1 // Static, for glitch freedom  
   d.addDependent(this) // To be notified in the future
-  dependOn += d
+  addDependOn(d)
   
   var storedVal: (Any,Any) = (null, null)
   
@@ -184,7 +184,7 @@ class InnerEventNode[T](d: DepHolder) extends EventNode[T] with Dependent {
 
   level = d.level + 1 // For glitch freedom  
   d.addDependent(this) // To be notified in the future
-  dependOn += d
+  addDependOn(d)
   
   var storedVal: Any = _
   
@@ -219,7 +219,7 @@ class EventNodeOr[T](ev1: Event[_ <: T], ev2: Event[_ <: T]) extends EventNode[T
   level = (ev1.level max ev2.level) + 1 // For glitch freedom  
   ev1.addDependent(this) // To be notified in the future
   ev2.addDependent(this)
-  dependOn ++= List(ev1,ev2)
+  addAllDependOn(List(ev1,ev2))
   
   var storedVal: Any = _
   
@@ -255,7 +255,7 @@ class EventNodeAnd[T1, T2, T](ev1: Event[T1], ev2: Event[T2], merge: (T1, T2) =>
   level = (ev1.level max ev2.level) + 1 // For glitch freedom  
   ev1.addDependent(this) // To be notified in the future
   ev2.addDependent(this)
-  dependOn ++= List(ev1,ev2)
+  addAllDependOn(List(ev1,ev2))
   
   var storedValEv1: T1 = _
   var storedValEv2: T2 = _
@@ -294,7 +294,7 @@ class EventNodeFilter[T](ev: Event[T], f: T => Boolean) extends EventNode[T] wit
 
   level = ev.level + 1   // For glitch freedom  
   ev.addDependent(this) // To be notified in the future
-  dependOn += ev
+  addDependOn(ev)
   
   var storedVal: T = _
   
@@ -322,7 +322,7 @@ class EventNodeMap[T, U](ev: Event[T], f: T => U)
 
   level = ev.level + 1   // For glitch freedom  
   ev.addDependent(this) // To be notified in the future
-  dependOn += ev
+  addDependOn(ev)
   
   var storedVal: T = _
   
@@ -355,7 +355,7 @@ class EventNodeExcept[T](accepted: Event[T], except: Event[T])
   level = (accepted.level max except.level) + 1 // For glitch freedom  
   accepted.addDependent(this) // To be notified in the future
   except.addDependent(this)
-  dependOn ++= List(accepted,except)
+  addAllDependOn(List(accepted,except))
   
   var storedVal: Any = _
   

--- a/REScalaTests/test/react/test/DependenciesTestSuite.scala
+++ b/REScalaTests/test/react/test/DependenciesTestSuite.scala
@@ -81,6 +81,7 @@ class DependenciesTestSuite extends AssertionsForJUnit with MockitoSugar {
     assert(v2.dependents.size == 1)
     assert(v3.dependents.size == 1)
     assert(s.dependents.size == 0)
+    // TODO why is s.dependOn.size 3!?
     assert(s.dependOn.size == 2)
   }
 


### PR DESCRIPTION
While investigating another bug regarding REClipse, I encountered a bug in REScala. REScala stores dependencies multiple times under certain circumstances (when variables are re-evaluated). This does not make any sense. Hence, I fixed this problem and wrote a dependencies test suite.

The `dependOn` / `dependents` attribute should not be altered directly, but through the respective methods such as `addDependOn`. In order to prevent direct manipulation, I thought about defining the attributes as private, but this makes testing more difficult: Either one writes getter methods just for testing purposes (I hate having methods just for testing purposes) or one uses reflection (but I was not able to get the attributes of the trait via reflection :( ).
