### PR TITLE
Fixed Var Initialization Order

### DIFF
--- a/REScala/src/rescala/Deprecated.scala
+++ b/REScala/src/rescala/Deprecated.scala
@@ -9,9 +9,7 @@ import rescala.events._
  */
 
 /* An implementation of Var with static dependencies */
-class StaticVar[T](initval: T) extends Var[T] {
-  private[this] var value: T = initval
-
+class StaticVar[T](private[this] var value: T) extends Var[T] {
   def set(newval: T): Unit = {
     val old = value
     if (newval != old) {

--- a/REScala/src/rescala/DynamicDepReactives.scala
+++ b/REScala/src/rescala/DynamicDepReactives.scala
@@ -13,9 +13,7 @@ import rescala.events.EventNode
 //}
 
 /* A node that has nodes that depend on it */
-class VarSynt[T](initval: T) extends Var[T] {
-  private[this] var value: T = initval
-
+class VarSynt[T](private[this] var value: T) extends Var[T] {
   def get = value
 
   def set(newval: T): Unit = {


### PR DESCRIPTION
I simplified the field definition and initialization of the `Var` classes. With the old code, it was not possible to get the initial value when the log method `nodeCreated` has been called. With the new version, this is possible. This is due to the Scala initialization order. A [StackOverflow question](https://stackoverflow.com/questions/3830332/scala-initialization-behaviour) exemplifies the problem.
