### PR TITLE
Add .gitattributes, with auto crlf

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -23,3 +23,7 @@ indent_size = 2
 [*.{yml,yaml}]
 indent_style = space
 indent_size = 2
+
+# Windows-style newlines, even on Unix
+[*.{bat,cmd,ps1}]
+end_of_line = crlf

--- a/.editorconfig
+++ b/.editorconfig
@@ -27,3 +27,7 @@ indent_size = 2
 # Windows-style newlines, even on Unix
 [*.{bat,cmd,ps1}]
 end_of_line = crlf
+
+# Unix-style newlines, even on Windows
+[*.sh]
+end_of_line = lf

--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,6 @@
 root = true
 
 [*]
-end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 # Autodetect text files and ensure that we normalise their line endings to lf internally.
-# By default, checkout with lf line endings.
-* text=auto eol=lf
+# When checked out they may use different line endings.
+* text=auto
 
 # Always checkout with crlf (Windows) line endings
 *.bat text eol=crlf
@@ -9,3 +9,7 @@
 
 # Always checkout with lf (UNIX) line endings
 *.sh text eol=lf
+
+# For the remaining files the line endings of checked out
+# files is defined by the ``core.eol`` git config variable.
+# By default this is the native line ending for the platform.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Autodetect text files and ensure that we normalise their line endings to lf internally.
+# By default, checkout with lf line endings.
+* text=auto eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,8 @@
 # Autodetect text files and ensure that we normalise their line endings to lf internally.
 # By default, checkout with lf line endings.
 * text=auto eol=lf
+
+# Always checkout with crlf (Windows) line endings
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,6 @@
 *.bat text eol=crlf
 *.cmd text eol=crlf
 *.ps1 text eol=crlf
+
+# Always checkout with lf (UNIX) line endings
+*.sh text eol=lf


### PR DESCRIPTION
Currently, .editorconfig defines that all files should have lf line endings.

However, as there is no .gitattributes file, on Windows, git is checking out text files as crlf.

This leads to inconsistent line endings (and warnings by git) on Windows, as an editor creates new files with lf but git expects crlf.

There are two possible solutions:
1. Tell git with .gitattributes to always checkout files with lf line endings.
2. Let git handle the line endings automatically based on the system preference, and enforce specific line endings only for a limited set of files.

This PR does both:
The first commit implements 1. which is the minimum to have consistent line endings on Windows (always lf, as intended by .editorconfig).
The remaining commits are implementing 2. and are optional, future-proofing, and a bit personal preference / experience.