### PR TITLE
DecomposeManualTests: trying to get it to work with ScalaJS

### DIFF
--- a/Modules/RDTs/src/test/scala/test/kofre/bespoke/DecomposeManualTests.scala
+++ b/Modules/RDTs/src/test/scala/test/kofre/bespoke/DecomposeManualTests.scala
@@ -107,8 +107,6 @@ class DecomposeManualTests extends munit.ScalaCheckSuite {
     val val_1: Dotted[LastWriterWins[Int]] = empty.write(1)
     assertEquals(val_1.read, 1)
 
-    Thread.sleep(1)
-
     val val_2: Dotted[LastWriterWins[Int]] = empty.write(2)
     assertEquals(val_2.read, 2)
 


### PR DESCRIPTION
Thread.sleep and Thread.yield are not available on ScalaJS. Just risk having the same time, it should work anyway.